### PR TITLE
Fix DB connection configuration

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -4,11 +4,11 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const pool = mysql.createPool({
-  host: "localhost",
-  user: "spkuser",
-  password: "spkpass",
-  database: "spk_electre",
-  port: 3306,
+  host: process.env.DB_HOST || "localhost",
+  user: process.env.DB_USER || "spkuser",
+  password: process.env.DB_PASS || "spkpass",
+  database: process.env.DB_NAME || "spk_electre",
+  port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0,


### PR DESCRIPTION
## Summary
- use environment variables for DB credentials

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68458b424118832b9a416a4b7dbefc0a