### PR TITLE
Add 404 and global error handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,4 +36,15 @@ app.use("/api/kuisioner", kuisionerRoutes);
 app.use("/api/electre", electreRoutes);
 app.use("/api/nilai_alternatif", nilaiAlternatifRoutes);
 
+// Middleware 404 untuk rute yang tidak ditemukan
+app.use((req, res) => res.status(404).json({ message: "Not Found" }));
+
+// Middleware error handler
+app.use((err, req, res, next) => {
+  console.error(err);
+  res
+    .status(err.status || 500)
+    .json({ message: err.message || "Internal Server Error" });
+});
+
 app.listen(3000, () => console.log("Server running on http://localhost:3000"));


### PR DESCRIPTION
## Summary
- register 404 middleware after all routes
- add global error handling middleware in `app.js`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68458df6e5d0832bb6666af7035648ad